### PR TITLE
Stabilization: Prevents panicking on response errors

### DIFF
--- a/src/measured_response.rs
+++ b/src/measured_response.rs
@@ -19,9 +19,9 @@ pub enum StatusOrError {
 
 impl fmt::Display for StatusOrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &StatusOrError::Status(status) => status.fmt(f),
-            &StatusOrError::ResponseError => write!(f, "Response error"),
+        match *self {
+            StatusOrError::Status(status) => status.fmt(f),
+            StatusOrError::ResponseError => write!(f, "Response error"),
         }
     }
 }


### PR DESCRIPTION
This commits prevents the program to crash when the response is malformed, times-out or even the server is down.

It will register the status as a `Response Error`, but we still can't provide more information about it.
