### PR TITLE
Sorts import and module usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
+extern crate arrayvec;
 extern crate clap;
 extern crate hyper;
+extern crate screenprints;
 extern crate stopwatch;
 extern crate time;
-extern crate screenprints;
-extern crate arrayvec;
 extern crate url;
 
 mod measured_response;
@@ -12,8 +12,8 @@ mod summary;
 use measured_response::MeasuredResponse;
 use summary::Summary;
 
-use std::str::FromStr;
 use std::io::{stdout, Write};
+use std::str::FromStr;
 use std::time::Duration;
 
 use clap::{App, Arg};

--- a/src/measured_response.rs
+++ b/src/measured_response.rs
@@ -1,13 +1,12 @@
+use std::fmt;
 use std::time::Duration;
 
-use stopwatch::Stopwatch;
-
 use hyper::Client;
+use hyper::Url;
 use hyper::header::Connection;
 use hyper::status::StatusCode;
-use hyper::Url;
 
-use std::fmt;
+use stopwatch::Stopwatch;
 
 use time::Duration as TimeDuration;
 

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,5 +1,6 @@
-use arrayvec::ArrayVec;
 use measured_response::MeasuredResponse;
+
+use arrayvec::ArrayVec;
 
 const LAST_REQUEST_STORAGE_SIZE: usize = 10;
 


### PR DESCRIPTION
This commit sorts the module usages and imports on the following order:
- extern crats alphabetically
- std alphabetically
- project's modules alphabetically
- other modules alphabetically
