### PR TITLE
Feature: Allows redefinition of read timeout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,10 +23,12 @@ use screenprints::Printer;
 use url::Url;
 
 const DEFAULT_INTERVAL_IN_SECONDS: u64 = 10;
+const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 10;
 
 struct ApplicationConfiguration {
     url: String,
     interval: Duration,
+    timeout: Duration,
 }
 
 impl ApplicationConfiguration {
@@ -42,7 +44,11 @@ impl ApplicationConfiguration {
 fn url_validator(arg: String) -> Result<(), String> {
     match Url::parse(&arg) {
         Ok(_) => Ok(()),
-        Err(_) => Err("The url argument must be complete, specifying the protocol as well. For example: http://example.com".to_string()),
+        Err(_) => {
+            Err("The url argument must be complete, specifying the protocol as well. For example: \
+                 http://example.com"
+                    .to_string())
+        }
     }
 }
 
@@ -53,7 +59,8 @@ fn main() {
     let mut printer = Printer::new(stdout(), Duration::from_millis(10));
 
     loop {
-        let measured_response = MeasuredResponse::request(&application_configuration.url);
+        let measured_response = MeasuredResponse::request(&application_configuration.url,
+                                                          application_configuration.timeout);
         let next_tick = application_configuration.next_request_in(measured_response.std_time());
 
         summary.push(measured_response);
@@ -89,6 +96,9 @@ fn parse_arguments() -> ApplicationConfiguration {
     let interval_help_message = format!("The interval in seconds between requests, default to {} \
                                          seconds",
                                         DEFAULT_INTERVAL_IN_SECONDS);
+    let timeout_help_message = format!("The timeout in seconds to wait for a response, default \
+                                        to {} seconds",
+                                       DEFAULT_TIMEOUT_IN_SECONDS);
 
     let cli_arguments = App::new("heartbeat")
                             .version("v0.1.0-beta")
@@ -98,6 +108,12 @@ fn parse_arguments() -> ApplicationConfiguration {
                                      .takes_value(true)
                                      .value_name("INTERVAL")
                                      .help(&interval_help_message))
+                            .arg(Arg::with_name("timeout")
+                                     .long("timeout")
+                                     .short("t")
+                                     .takes_value(true)
+                                     .value_name("TIMEOUT")
+                                     .help(&timeout_help_message))
                             .arg(Arg::with_name("url")
                                      .long("url")
                                      .index(1)
@@ -113,9 +129,14 @@ fn parse_arguments() -> ApplicationConfiguration {
         u64::from_str(arg).expect("The interval argument requires a number")
     });
 
+    let timeout_argument = cli_arguments.value_of("timeout").map(|arg| {
+        u64::from_str(arg).expect("The timeout argument requires a number")
+    });
+
     ApplicationConfiguration {
         url: cli_arguments.value_of("url").expect("URL not present").to_string(),
         interval: Duration::from_secs(interval_argument.unwrap_or(DEFAULT_INTERVAL_IN_SECONDS)),
+        timeout: Duration::from_secs(timeout_argument.unwrap_or(DEFAULT_TIMEOUT_IN_SECONDS)),
     }
 }
 
@@ -124,6 +145,7 @@ fn next_tick_should_remove_the_time_spent_on_the_request() {
     let configuration = ApplicationConfiguration {
         url: Default::default(),
         interval: Duration::from_secs(3),
+        timeout: Duration::from_secs(0),
     };
 
     let time_spent = Duration::from_secs(1);
@@ -137,6 +159,7 @@ fn next_tick_should_be_right_away_when_more_time_is_spent() {
     let configuration = ApplicationConfiguration {
         url: Default::default(),
         interval: Duration::from_secs(3),
+        timeout: Duration::from_secs(0),
     };
 
     let time_spent = Duration::from_secs(5);

--- a/src/measured_response.rs
+++ b/src/measured_response.rs
@@ -13,7 +13,7 @@ use time::Duration as TimeDuration;
 #[derive(Debug, Eq, PartialEq)]
 pub enum StatusOrError {
     Status(StatusCode),
-    ResponseError
+    ResponseError,
 }
 
 impl fmt::Display for StatusOrError {
@@ -59,12 +59,12 @@ impl MeasuredResponse {
         }
     }
 
-    pub fn request(url: &str) -> MeasuredResponse {
+    pub fn request(url: &str, timeout: Duration) -> MeasuredResponse {
         let mut client = Client::new();
-        client.set_read_timeout(Some(Duration::from_secs(10)));
+        client.set_read_timeout(Some(timeout));
 
         let request = client.get(url)
-            .header(Connection::close());
+                            .header(Connection::close());
 
         let stop_watch = Stopwatch::start_new();
 


### PR DESCRIPTION
This commit allows the command line interface to change the timeout of
the connection. By default, it is 10 seconds.

This commit also had a run of `cargo fmt`, some changes are stylistic
instead of because of the feature.
