### PR TITLE
Follow redirect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = "0.1.0"
 dependencies = [
  "arrayvec 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "screenprints 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.8.1 (git+https://github.com/bltavares/hyper?branch=redirect_count)",
+ "screenprints 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stopwatch 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -51,7 +51,7 @@ dependencies = [
  "openssl 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -82,8 +82,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.8.1"
+source = "git+https://github.com/bltavares/hyper?branch=redirect_count#9e1a3d3fb1d9e13778dc5596dec0dd37b67af548"
 dependencies = [
  "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -98,7 +98,7 @@ dependencies = [
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -117,12 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -161,19 +161,76 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "num-bigint 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "num-complex"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -188,8 +245,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys-extras 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -200,7 +257,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -212,7 +269,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -234,7 +291,7 @@ name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -252,8 +309,12 @@ dependencies = [
 
 [[package]]
 name = "screenprints"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "semver"
@@ -274,7 +335,7 @@ name = "stopwatch"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -297,7 +358,7 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -339,7 +400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "url"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 [dependencies]
 arrayvec = "0.3.16"
 clap = "2.2.2"
-hyper = "0.8.0"
+hyper = { git = "https://github.com/bltavares/hyper", branch = "redirect_count" }
 screenprints = "0.1.0"
 stopwatch = "0.0.6"
 time = "0.1.35"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ While it is running, you can change the response using some provided methods [[d
 
 ## Unresolved and documented flaws
 
-- Does not work with redirects
+- Infinite redirects are followed
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ While it is running, you can change the response using some provided methods [[d
 
 ## Unresolved and documented flaws
 
-- Infinite redirects are followed
-
 ## Roadmap
 
 - Wave 1: Stabilization

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,13 @@ use url::Url;
 
 const DEFAULT_INTERVAL_IN_SECONDS: u64 = 10;
 const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 10;
+const DEFAULT_REDIRECT_LIMIT_COUNT: u8 = 5;
 
 struct ApplicationConfiguration {
     url: String,
     interval: Duration,
     timeout: Duration,
+    redirect_limit: u8,
 }
 
 impl ApplicationConfiguration {
@@ -60,7 +62,8 @@ fn main() {
 
     loop {
         let measured_response = MeasuredResponse::request(&application_configuration.url,
-                                                          application_configuration.timeout);
+                                                          application_configuration.timeout,
+                                                          application_configuration.redirect_limit);
         let next_tick = application_configuration.next_request_in(measured_response.std_time());
 
         summary.push(measured_response);
@@ -100,6 +103,10 @@ fn parse_arguments() -> ApplicationConfiguration {
                                         to {} seconds",
                                        DEFAULT_TIMEOUT_IN_SECONDS);
 
+    let redirect_limit_message = format!("The amount of redirects to follow, defaults to {} \
+                                          redirects",
+                                         DEFAULT_REDIRECT_LIMIT_COUNT);
+
     let cli_arguments = App::new("heartbeat")
                             .version("v0.1.0-beta")
                             .arg(Arg::with_name("interval")
@@ -114,6 +121,12 @@ fn parse_arguments() -> ApplicationConfiguration {
                                      .takes_value(true)
                                      .value_name("TIMEOUT")
                                      .help(&timeout_help_message))
+                            .arg(Arg::with_name("redirect_limit")
+                                     .long("follow")
+                                     .short("F")
+                                     .takes_value(true)
+                                     .value_name("FOLLOW COUNT")
+                                     .help(&redirect_limit_message))
                             .arg(Arg::with_name("url")
                                      .long("url")
                                      .index(1)
@@ -133,10 +146,15 @@ fn parse_arguments() -> ApplicationConfiguration {
         u64::from_str(arg).expect("The timeout argument requires a number")
     });
 
+    let redirect_limit_argument = cli_arguments.value_of("redirect_limit").map(|arg| {
+        u8::from_str(arg).expect("The redirect limit requires a number")
+    });
+
     ApplicationConfiguration {
         url: cli_arguments.value_of("url").expect("URL not present").to_string(),
         interval: Duration::from_secs(interval_argument.unwrap_or(DEFAULT_INTERVAL_IN_SECONDS)),
         timeout: Duration::from_secs(timeout_argument.unwrap_or(DEFAULT_TIMEOUT_IN_SECONDS)),
+        redirect_limit: redirect_limit_argument.unwrap_or(DEFAULT_REDIRECT_LIMIT_COUNT),
     }
 }
 
@@ -146,6 +164,7 @@ fn next_tick_should_remove_the_time_spent_on_the_request() {
         url: Default::default(),
         interval: Duration::from_secs(3),
         timeout: Duration::from_secs(0),
+        redirect_limit: 1,
     };
 
     let time_spent = Duration::from_secs(1);
@@ -160,6 +179,7 @@ fn next_tick_should_be_right_away_when_more_time_is_spent() {
         url: Default::default(),
         interval: Duration::from_secs(3),
         timeout: Duration::from_secs(0),
+        redirect_limit: 1,
     };
 
     let time_spent = Duration::from_secs(5);

--- a/src/measured_response.rs
+++ b/src/measured_response.rs
@@ -5,6 +5,7 @@ use hyper::Client;
 use hyper::Url;
 use hyper::header::Connection;
 use hyper::status::StatusCode;
+use hyper::client::RedirectPolicy;
 
 use stopwatch::Stopwatch;
 
@@ -59,9 +60,10 @@ impl MeasuredResponse {
         }
     }
 
-    pub fn request(url: &str, timeout: Duration) -> MeasuredResponse {
+    pub fn request(url: &str, timeout: Duration, redirect_count: u8) -> MeasuredResponse {
         let mut client = Client::new();
         client.set_read_timeout(Some(timeout));
+        client.set_redirect_policy(RedirectPolicy::FollowCount(redirect_count));
 
         let request = client.get(url)
                             .header(Connection::close());

--- a/test-server/README.md
+++ b/test-server/README.md
@@ -25,6 +25,10 @@ irb> alive
 # will respond again
 irb> speed 1
 # will take 1 second to respond
+irb> redirect
+# will redirect 1 time and then ok
+irb> redirect 2
+# will redirect 2 times and then ok
 irb> exit
 # will exit the application
 ```

--- a/test-server/server.rb
+++ b/test-server/server.rb
@@ -5,10 +5,12 @@ require 'irb/completion'
 OK = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
 NOT_FOUND = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
 ERROR = "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"
+REDIRECT = "HTTP/1.1 301 Redirect\r\nLocation: /\r\n\r\n"
 
 @@live = true
 @@response = OK
 @@sleep = 0
+@@redirect = 0
 
 port = ENV.fetch('PORT', 7125)
 puts "Starting server at localhost:#{port}"
@@ -18,6 +20,8 @@ server = Thread.new do
     puts 'Received request'
     sleep @@sleep
     session.print @@response if @@live
+    @@redirect = @@redirect.pred if @@response == REDIRECT
+    ok if @@redirect.zero?
     session.close
   end
 end
@@ -41,6 +45,11 @@ end
 
 def dead
   @@live = false
+end
+
+def redirect times=1
+  @@redirect = times
+  @@response = REDIRECT
 end
 
 def speed(amount)


### PR DESCRIPTION
Allows the application to follow, up to a certain amount, redirects sent before resolving the URL.

The time calculation considers the whole redirect chain, from the first until it reaches the limit.
